### PR TITLE
Vorschlag zur Korrektur von Beispiel- und Basispolicies

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,6 @@
 # Release 4.0.0-Pre1
-- Änderungen die für ePA 2.0 notwendig wurden - Änderungen an der Schnittstelle des VZD, die für das eRezept notwendig wurden - Aufnahme von Schemahärtungen für die Signatur Schnittstelle des Konnektors - Aufnahme notwendiger Korrekturen und Optimierungen, die sich aus den laufenden Entwicklungs- bzw. Zulassungsprozessen ergeben haben
+- Änderungen die für ePA 2.0 notwendig wurden 
+- Änderungen an der Schnittstelle des VZD, die für das eRezept notwendig wurden 
+- Aufnahme von Schemahärtungen für die Signatur Schnittstelle des Konnektors 
+- Aufnahme notwendiger Korrekturen und Optimierungen, die sich aus den laufenden Entwicklungs- bzw. Zulassungsprozessen ergeben haben
 

--- a/fd/phr/appc/base-policy-hcp.xml
+++ b/fd/phr/appc/base-policy-hcp.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- gematik revision="\main\rel_ors2\1" -->
-<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:policy:schema:os ../../../../ext/IHE/ihe-appc-xacml-combined-schema-1.0.xsd" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:uuid:cb74359d-485b-4bd4-b7c9-cc7a0c5a53f2" Version="1.0.1">	
+<!-- BEISPIELPOLICY -->
+<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" 
+    PolicySetId="urn:uuid:cb74359d-485b-4bd4-b7c9-cc7a0c5a53f2" Version="1.0.1">	
 	<Target>
 		<Subjects>
 			<Subject>
@@ -10,7 +12,7 @@
 						<InstanceIdentifier xmlns="urn:hl7-org:v3" extension="1-2c47sd-e518" root="1.2.276.0.76.4.188"/>
 					</AttributeValue>
 					<SubjectAttributeDesignator AttributeId="urn:gematik:subject:organization-id" DataType="urn:hl7-org:v3#II" MustBePresent="true"/>
-				</SubjectMatch>
+				</SubjectMatch> 
 			</Subject>
 			<!-- OR -->
 			<Subject>
@@ -35,7 +37,7 @@
 		<Environments>
 			<Environment>
 				<EnvironmentMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:date-less-than-or-equal">
-					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#dateTime">2018-10-15</AttributeValue>
+					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#date">2018-10-15</AttributeValue>
 					<EnvironmentAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#date" AttributeId="urn:oasis:names:tc:xacml:1.0:environment:current-date"/>
 				</EnvironmentMatch>
 				<!-- AND -->

--- a/fd/phr/appc/base-policy-insurance.xml
+++ b/fd/phr/appc/base-policy-insurance.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- gematik revision="\main\rel_ors2\1" -->
-<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:policy:schema:os ../../../../ext/IHE/ihe-appc-xacml-combined-schema-1.0.xsd" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:uuid:cb74359d-485b-4bd4-b7c9-cc7a0c5a53f2" Version="1.0.1">	
+<!-- BEISPIELPOLICY -->
+<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" 
+    PolicySetId="urn:uuid:cb74359d-485b-4bd4-b7c9-cc7a0c5a53f2" Version="1.0.1">	
 	<Target>
 		<Subjects>
 			<Subject>

--- a/fd/phr/appc/base-policy-insurant.xml
+++ b/fd/phr/appc/base-policy-insurant.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- gematik revision="\main\rel_ors2\1" -->
-<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:policy:schema:os ../../../../ext/IHE/ihe-appc-xacml-combined-schema-1.0.xsd" xmlns:hl7="urn:hl7-org:v3" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:insurant" Version="1.0.1">
-	<Description></Description>
+<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" 
+    PolicySetId="urn:gematik:policy-set-id:insurant" Version="1.0.1">
 	<Target>
 		<Subjects>
 			<Subject>

--- a/fd/phr/appc/base-policy-representative.xml
+++ b/fd/phr/appc/base-policy-representative.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- gematik revision="\main\rel_ors2\1" -->
-<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:policy:schema:os ../../../../ext/IHE/ihe-appc-xacml-combined-schema-1.0.xsd" xmlns:hl7="urn:hl7-org:v3" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:uuid:0c13dd6f-5a5c-4c90-819b-7d74a61c9f52" Version="1.0.1">
-	<Description/>
+<!-- BEISPIELPOLICY -->
+<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" 
+    PolicySetId="urn:uuid:0c13dd6f-5a5c-4c90-819b-7d74a61c9f52" Version="1.0.1">
 	<Target>
 		<Subjects>
 			<Subject>

--- a/fd/phr/appc/permission-policy-hcp-insurance-documents.xml
+++ b/fd/phr/appc/permission-policy-hcp-insurance-documents.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:policy:schema:os ../../../../ext/IHE/ihe-appc-xacml-combined-schema-1.0.xsd" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-hcp-insurance-documents" Version="1.0.1">
+<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-hcp-insurance-documents" Version="1.0.1">
 	<Target/>
 	<Policy PolicyId="urn:uuid:d868da89-f24c-4605-8fb1-30cca020bc71" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides">
 		<Target>

--- a/fd/phr/appc/permission-policy-hcp-insurant-documents.xml
+++ b/fd/phr/appc/permission-policy-hcp-insurant-documents.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:policy:schema:os ../../../../ext/IHE/ihe-appc-xacml-combined-schema-1.0.xsd" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-hcp-insurant-documents" Version="1.0.1">
+<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-hcp-insurant-documents" Version="1.0.1">
 	<Target/>
 	<Policy PolicyId="urn:uuid:d6ffba13-7188-45ed-8688-f5fbfd4a99d1" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides">
 		<Target>

--- a/fd/phr/appc/permission-policy-hcp.xml
+++ b/fd/phr/appc/permission-policy-hcp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:policy:schema:os ../../../../ext/IHE/ihe-appc-xacml-combined-schema-1.0.xsd" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-hcp" Version="1.0.1">
+<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-hcp" Version="1.0.1">
 	<Target/>
 	<Policy PolicyId="urn:uuid:2b6e81c2-ed3b-4416-aeaf-e80ab0a7c3e3" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides">
 		<Target>

--- a/fd/phr/appc/permission-policy-insurance.xml
+++ b/fd/phr/appc/permission-policy-insurance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- gematik revision="\main\rel_ors2\9" -->
-<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:policy:schema:os ../../../../ext/IHE/ihe-appc-xacml-combined-schema-1.0.xsd" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-insurance" Version="1.0.1">
+<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-insurance" Version="1.0.1">
 	<Target/>
 	<Policy PolicyId="urn:uuid:e84a950d-7e73-4ca5-865d-035bc7f381f4" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides">
 		<Target>

--- a/fd/phr/appc/permission-policy-insurant.xml
+++ b/fd/phr/appc/permission-policy-insurant.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- gematik revision="\main\rel_ors2\9" -->
-<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:policy:schema:os ../../../../ext/IHE/ihe-appc-xacml-combined-schema-1.0.xsd" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-insurant" Version="1.0.1">
+<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-insurant" Version="1.0.1">
 	<Target/>
 	<Policy PolicyId="urn:uuid:e84a950d-7e73-4ca5-865d-035bc7f381f4" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides">
 		<Target>

--- a/fd/phr/appc/permission-policy-representative.xml
+++ b/fd/phr/appc/permission-policy-representative.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- gematik revision="\main\rel_ors2\8" -->
-<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:policy:schema:os ../../../../ext/IHE/ihe-appc-xacml-combined-schema-1.0.xsd" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-representative" Version="1.0.1">
+<PolicySet xmlns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" PolicyCombiningAlgId="urn:oasis:names:tc:xacml:1.0:policy-combining-algorithm:deny-overrides" PolicySetId="urn:gematik:policy-set-id:permissions-access-group-representative" Version="1.0.1">
 	<Target/>
 	<Policy PolicyId="urn:uuid:c7bec7f0-369f-4808-aa50-9b448c846010" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides">
 		<Target>


### PR DESCRIPTION
* Falscher Datentyp in base-policy-hcp.xml (Tab_Dokv_300-01)
* Verwendung von schemaLocation entfernt (verboten gemäß A_15536-01)
* Vermerk als "Beispielpolicy" für alle Policies die nur als Beispiel
anzusehen sind (ggf. sollte die Gematik für Beispiele zukünftig ein
separates Repository zur Verfügung stellen)