### PR TITLE
Header 'Accept: application/json' wird bei delete_Directory_Entry benötigt

### DIFF
--- a/vzd/DirectoryAdministration.yaml
+++ b/vzd/DirectoryAdministration.yaml
@@ -547,7 +547,9 @@ paths:
       responses:
         200:
           description: OK
-          content: {}
+          content:
+            application/json:
+                schema: {}
         400:
           description: Bad Request
                      # Invalid ID supplied


### PR DESCRIPTION
https://gematik.atlassian.net/servicedesk/customer/portal/28/ANFVZS-59

Das Löschen eines Verzeichniseintrags geht nur mit dem Header 'Accept: application/json'. Die Anwort ist aber immer leer und daher kein valides JSON. 
Ohne Accept-Header kommt der Fehler-Code 405 - Method Not Allowed.
Dies ist ein Fehler in der API.

Das Problem ist hier, dass der Header in einem aus der OpenAPI Spezifikation automatisch generierten Client nicht vorhanden ist.