### PR TITLE
Korrektur von ProvisioningService.xsd

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,11 +1,11 @@
 # Release 4.0.4-0
-- Structure: removals from content of the directory /phr corrected\n
+- Structure: removals from content of the directory /phr corrected
 
 # Release 4.0.4
-- VPNZugD: data type of user data specified (C_10805 in ProvisioningService.xsd)\n 
-- Structure: directories /tel and /ext linked via subtree with the repo api-ePA\n 
-- Structure: content of the directory /phr moved to the repo api-ePA\n 
-- Other: Readme updated\n
+- VPNZugD: data type of user data specified (C_10805 in ProvisioningService.xsd)
+- Structure: directories /tel and /ext linked via subtree with the repo api-ePA
+- Structure: content of the directory /phr moved to the repo api-ePA
+- Other: Readme updated
 
 # Release 4.0.3-3
 - VZD: new operation delete_Directory_Entry_Certificate

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,33 +1,29 @@
 # Release 4.0.4-0
 - Structure: removals from content of the directory /phr corrected\n
 
-# Release test_remove_files
-Test git behaviour without ignoring removals
-
 # Release 4.0.4
-- VPNZugD: data type of user data specified (C_10805 in ProvisioningService.xsd)\n - Structure: directories /tel and /ext linked via subtree with the repo api-ePA\n - Structure: content of the directory /phr moved to the repo api-ePA\n - Other: Readme updated\n
+- VPNZugD: data type of user data specified (C_10805 in ProvisioningService.xsd)\n 
+- Structure: directories /tel and /ext linked via subtree with the repo api-ePA\n 
+- Structure: content of the directory /phr moved to the repo api-ePA\n 
+- Other: Readme updated\n
 
 # Release 4.0.3-3
 - VZD: new operation delete_Directory_Entry_Certificate
 
-
 # Release 4.0.3-2
 Changes for ePA Release 2.0.4-1
  - ePA_2.0.4-1: add parameter ProviderEncCertificate to SuspendAccountRequest (AccountManagementService.xsd)
-
 
 # Release 4.0.3-1
 Changes for ePA Release 2.0.4
  - ePA_2.0.4: clarification for DocumentUniqueId type (now rim:LongName in KeyManagementService.xsd)
  - ePA_2.0.4: changed cardinality of DocumentCategorElement in DocumentCategoryList (C_10796, PHRManagementService_V2_0.xsd)
 
-
 # Release 4.0.3
 - VPN_ZugD: Reverted ProvisioningService namespace to 1.1 (C_10724)
  - Konnektor (ePA): Removed PHRService 1.4.0. File names adapted to service version 2.0.1 (C_10725)
  - Konnektor (ePA): Removed files PHRService_V2_0.wsdl/xsd (C_10725)
  - Konnektor (Operating Data): Update SiteType value range, UpdateMode optional (C_10701)
-
 
 # Release 4.0.3-Pre1
 - ePA 2.0.4: C_10766 - removed GetRecordProviderList from AuthorizationService

--- a/vpnzugd/ProvisioningService.xsd
+++ b/vpnzugd/ProvisioningService.xsd
@@ -7,7 +7,7 @@
             ===========
             *** C_10805: Darstellung der kodierten Daten spezifiziert 
      End of Version History-->
-<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:VPNK="http://ws.gematik.de/vpnzugd/ProvisioningService/v1.1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://ws.gematik.de/vpnzugd/ProvisioningService/v1.1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1.2">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:VPNK="http://ws.gematik.de/vpnzugd/ProvisioningService/v1.1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://ws.gematik.de/vpnzugd/ProvisioningService/v1.1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1.2">
     <annotation>
         <documentation>
 		Copyright (c) 2021, gematik GmbH. Alle Rechte vorbehalten.


### PR DESCRIPTION
In der XML Schema Definition Datei "ProvisioningService.xsd" fehlt folgende XML Namespace Deklaration:
	xmlns:xs="http://www.w3.org/2001/XMLSchema"
Dadurch ist die Datei nicht schemavalide.

Prüfbar durch folgenden Shell-Befehl:
 $ xmllint --schema ProvisioningService.xsd "<root/>" --nowarning

Durch diesen Commit wird dies behoben.