### PR TITLE
Verbesserung von ProvisioningService.wsdl

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,11 +1,11 @@
 # Release 4.0.4-0
-- Structure: removals from content of the directory /phr corrected\n
+- Structure: removals from content of the directory /phr corrected
 
 # Release 4.0.4
-- VPNZugD: data type of user data specified (C_10805 in ProvisioningService.xsd)\n 
-- Structure: directories /tel and /ext linked via subtree with the repo api-ePA\n 
-- Structure: content of the directory /phr moved to the repo api-ePA\n 
-- Other: Readme updated\n
+- VPNZugD: data type of user data specified (C_10805 in ProvisioningService.xsd)
+- Structure: directories /tel and /ext linked via subtree with the repo api-ePA
+- Structure: content of the directory /phr moved to the repo api-ePA
+- Other: Readme updated
 
 # Release 4.0.3-3
 - VZD: new operation delete_Directory_Entry_Certificate

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,33 +1,29 @@
 # Release 4.0.4-0
 - Structure: removals from content of the directory /phr corrected\n
 
-# Release test_remove_files
-Test git behaviour without ignoring removals
-
 # Release 4.0.4
-- VPNZugD: data type of user data specified (C_10805 in ProvisioningService.xsd)\n - Structure: directories /tel and /ext linked via subtree with the repo api-ePA\n - Structure: content of the directory /phr moved to the repo api-ePA\n - Other: Readme updated\n
+- VPNZugD: data type of user data specified (C_10805 in ProvisioningService.xsd)\n 
+- Structure: directories /tel and /ext linked via subtree with the repo api-ePA\n 
+- Structure: content of the directory /phr moved to the repo api-ePA\n 
+- Other: Readme updated\n
 
 # Release 4.0.3-3
 - VZD: new operation delete_Directory_Entry_Certificate
 
-
 # Release 4.0.3-2
 Changes for ePA Release 2.0.4-1
  - ePA_2.0.4-1: add parameter ProviderEncCertificate to SuspendAccountRequest (AccountManagementService.xsd)
-
 
 # Release 4.0.3-1
 Changes for ePA Release 2.0.4
  - ePA_2.0.4: clarification for DocumentUniqueId type (now rim:LongName in KeyManagementService.xsd)
  - ePA_2.0.4: changed cardinality of DocumentCategorElement in DocumentCategoryList (C_10796, PHRManagementService_V2_0.xsd)
 
-
 # Release 4.0.3
 - VPN_ZugD: Reverted ProvisioningService namespace to 1.1 (C_10724)
  - Konnektor (ePA): Removed PHRService 1.4.0. File names adapted to service version 2.0.1 (C_10725)
  - Konnektor (ePA): Removed files PHRService_V2_0.wsdl/xsd (C_10725)
  - Konnektor (Operating Data): Update SiteType value range, UpdateMode optional (C_10701)
-
 
 # Release 4.0.3-Pre1
 - ePA 2.0.4: C_10766 - removed GetRecordProviderList from AuthorizationService

--- a/vpnzugd/ProvisioningService.wsdl
+++ b/vpnzugd/ProvisioningService.wsdl
@@ -64,7 +64,7 @@
     <wsdl:binding name="regBinding" type="VPNKW:provisioningPortType">
         <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
         <wsdl:operation name="regOperation">
-            <soap:operation soapAction="urn:#regOperation"/>
+            <soap:operation soapAction="http://ws.gematik.de/vpnzugd/ProvisioningService/v1.1#regOperation"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -76,7 +76,7 @@
             </wsdl:fault>
         </wsdl:operation>
         <wsdl:operation name="deregOperation">
-            <soap:operation soapAction="urn:#deregOperation"/>
+            <soap:operation soapAction="http://ws.gematik.de/vpnzugd/ProvisioningService/v1.1#deregOperation"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -88,7 +88,7 @@
             </wsdl:fault>
         </wsdl:operation>
         <wsdl:operation name="statusOperation">
-            <soap:operation soapAction="urn:#statusOperation"/>
+            <soap:operation soapAction="http://ws.gematik.de/vpnzugd/ProvisioningService/v1.1#statusOperation"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -100,7 +100,7 @@
             </wsdl:fault>
         </wsdl:operation>
         <wsdl:operation name="sendDataOperation">
-            <soap:operation soapAction="urn:#sendDataOperation"/>
+            <soap:operation soapAction="http://ws.gematik.de/vpnzugd/ProvisioningService/v1.1#sendDataOperation"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>


### PR DESCRIPTION
Das WSDL ProvisionService.wsdl verwendet bei Operationen die Soap Action soapAction="urn:#<op-name>".
Wobei <ob-name> der Name der Operation ist.
Dieser Service enthält als einziges "urn:" als Prefix. Andere WSDL
verwendet dafür ihren Namespace.

Es wird vermutet, dass es sich hierbei um ein Fehler handelt und "urn:"
durch "http://ws.gematik.de/vpnzugd/ProvisioningService/v1.1" ersetzt
gehört.