### PR TITLE
WSDL und XSD für QR-Code Funktion hinzugefügt

### DIFF
--- a/conn/CardTerminalService2DCode_v1_0_0-1.wsdl
+++ b/conn/CardTerminalService2DCode_v1_0_0-1.wsdl
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:GERROR="http://ws.gematik.de/tel/error/v2.0"
+             xmlns:CT2DCODE="http://ws.cgm.com/conn/CardTerminalService2DCode/v1.0.0"
+             xmlns:CT2DCODEW="http://ws.cgm.com/conn/CardTerminalService2DCode/WSDL/v1.0.0"
+             targetNamespace="http://ws.cgm.com/conn/CardTerminalService2DCode/WSDL/v1.0.0">
+    <documentation>
+        Beschreibung: Dienst zur Anzeige von 2D Codes auf Kartenterminals
+        version=1.0.0
+    </documentation>
+
+    <types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema">
+            <import schemaLocation="CardTerminalService2DCode_v1_0_0.xsd" namespace="http://ws.cgm.com/conn/CardTerminalService2DCode/v1.0.0"/>
+            <import schemaLocation="../../xsd/tel/error/TelematikError.xsd" namespace="http://ws.gematik.de/tel/error/v2.0"/>
+        </schema>
+    </types>
+
+    <message name="displayQRCodeRequestMessage">
+        <part name="parameter" element="CT2DCODE:DisplayQRCode"/>
+    </message>
+    <message name="displayQRCodeResponseMessage">
+        <part name="parameter" element="CT2DCODE:DisplayQRCodeResponse"/>
+    </message>
+    <message name="FaultMessage">
+        <part name="parameter" element="GERROR:Error"/>
+    </message>
+
+    <portType name="CardTerminalService2DCodePortType">
+        <operation name="display_qr_code">
+            <input message="CT2DCODEW:displayQRCodeRequestMessage"/>
+            <output message="CT2DCODEW:displayQRCodeResponseMessage"/>
+            <fault name="FaultMessage" message="CT2DCODEW:FaultMessage"/>
+        </operation>
+    </portType>
+
+    <binding name="CardTerminalService2DCodeBinding" type="CT2DCODEW:CardTerminalService2DCodePortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="display_qr_code">
+            <soap:operation soapAction="http://ws.cgm.com/conn/CardTerminalService2DCode/v1.0.0#displayQRCode"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="FaultMessage">
+                <soap:fault name="FaultMessage" use="literal"/>
+            </fault>
+        </operation>
+    </binding>
+
+    <service name="CardTerminalService2DCode">
+        <port name="CardTerminalService2DCodePort" binding="CT2DCODEW:CardTerminalService2DCodeBinding">
+            <soap:address location="http://ti-konnektor/service/cardterminal2dcodeservice"/>
+        </port>
+    </service>
+</definitions>
+

--- a/conn/CardTerminalService2DCode_v1_0_0-1.xsd
+++ b/conn/CardTerminalService2DCode_v1_0_0-1.xsd
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version History
+            version: V1.0.0
+			* Initiale Erstellung
+	 End of Version History-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:CT2DCODE="http://ws.cgm.com/conn/CardTerminalService2DCode/v1.0.0"
+        xmlns:CARDCMN="http://ws.gematik.de/conn/CardServiceCommon/v2.0"
+        xmlns:CONN="http://ws.gematik.de/conn/ConnectorCommon/v5.0"
+        xmlns:CCTX="http://ws.gematik.de/conn/ConnectorContext/v2.0"
+        targetNamespace="http://ws.cgm.com/conn/CardTerminalService2DCode/v1.0.0"
+        elementFormDefault="qualified"
+        attributeFormDefault="unqualified"
+        version="1.0.0">
+    <annotation>
+        <documentation xml:lang="de">
+            Copyright (c) 2023, CGM Deutschland AG. Alle Rechte
+            vorbehalten.
+            Beschreibung: Dienst zur Anzeige von 2D Codes auf Kartenterminals
+        </documentation>
+    </annotation>
+    <import namespace="http://ws.gematik.de/conn/ConnectorCommon/v5.0"
+            schemaLocation="../../xsd/conn/ConnectorCommon.xsd"/>
+    <import namespace="http://ws.gematik.de/conn/CardServiceCommon/v2.0"
+            schemaLocation="../../xsd/conn/CardServiceCommon.xsd"/>
+    <import namespace="http://ws.gematik.de/conn/ConnectorContext/v2.0"
+            schemaLocation="../../xsd/conn/ConnectorContext.xsd"/>
+
+    <element name="DisplayQRCode">
+        <complexType>
+            <sequence>
+                <element ref="CCTX:Context"/>
+                <element ref="CARDCMN:CtId"/>
+                <element name="DisplayMsg" type="CT2DCODE:DisplayMsgType"/>
+                <element name="TimeOut" type="CT2DCODE:TimeOutType" default="20"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="DisplayQRCodeResponse">
+        <complexType>
+            <sequence>
+                <element ref="CONN:Status"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <complexType name="DisplayMsgType">
+        <simpleContent>
+            <extension base="CT2DCODE:BinaryMsgType">
+                <attribute ref="CT2DCODE:codetype"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+
+    <simpleType name="BinaryMsgType">
+        <restriction base="base64Binary">
+            <maxLength value="512"/>
+        </restriction>
+    </simpleType>
+
+    <attribute name="codetype" default="QR_CODE">
+        <simpleType>
+            <restriction base="string">
+                <enumeration value="QR_CODE"/>
+                <enumeration value="DATA_MATRIX_CODE"/>
+            </restriction>
+        </simpleType>
+    </attribute>
+
+    <simpleType name="TimeOutType">
+        <restriction base="positiveInteger">
+            <minInclusive value="5"/>
+            <maxInclusive value="60"/>
+        </restriction>
+    </simpleType>
+</schema>
+


### PR DESCRIPTION
SOAP-Endpunkt:
```xml
<ns3:Service Name="HerstellerspezifischerService">
   <ns3:Abstract>Service mit herstellerspezifischen Operationen</ns3:Abstract>
   <ns3:Versions>
      <ns3:Version TargetNamespace=<tbd> Version="1.0.0">
         <ns3:Abstract>
            Herstellerspezifische Operationen gemäß WSDL 1.0.0
         </ns3:Abstract>
         <ns3:Endpoint Location="http://<IP>:80/service/herstellerspezifischerservice"/>
         <ns3:EndpointTLS Location="https://<IP>:443/service/herstellerspezifischerservice"/>
      </ns3:Version>
   </ns3:Versions>
</ns3:Service>
```
Request:
```xml
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v1="http://ws.gematik.de/conn/CardTerminalService/v1.1" xmlns:v2="http://ws.gematik.de/conn/ConnectorContext/v2.0" xmlns:v5="http://ws.gematik.de/conn/ConnectorCommon/v5.0" xmlns:v21="http://ws.gematik.de/conn/CardServiceCommon/v2.0">
   <soapenv:Header/>
   <soapenv:Body>
      <v1:DisplayQRCode>
         <v2:Context>
            <v5:MandantId>?</v5:MandantId>
            <v5:ClientSystemId>?</v5:ClientSystemId>
            <v5:WorkplaceId>?</v5:WorkplaceId>
            <!--Optional:-->
            <v5:UserId>?</v5:UserId>
         </v2:Context>
         <v21:CtId>?</v21:CtId>
         <v1:DisplayMsg charset=?>?</v1:DisplayMsg>(string maxLength 512, muss umdefiniert werden, weil 48 zu wenig ist; charset=(ISO 18004 oder ISO 16022))
         <v1:TimeOut>?</v1:TimeOut> (mininclusiv = 5 maxinclusiv = 60) 
      </v1:DisplayQRCode>
   </soapenv:Body>
</soapenv:Envelope>
```
Ablauf:
| Nr.   | Aufruf Technischer Use Case oder Interne Operation              | Beschreibung                                                                                                                                                                                                                                                                                                                                 | Kommentare                                                                                                                                           |
| ----- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
| Nr. 1 | checkArguments                                                  | Die übergebenen Werte werden auf Konsistenz und Gültigkeit überprüft. Treten hierbei Fehler auf, so bricht die Operation mit Fehler 4000 ab.                                                                                                                                                                                                 | nur Schemaprüfung (charSet hat nur 2 gültige Werte. Es wird versucht dies im Schema abzubilden. Alternativ muss dies in der Fascade geprüft werden.) |
| Nr. 2 | TUC_KON_000 „Prüfe Zugriffsberechtigung“                        | Prüfung der Zugriffsberechtigung durch den Aufruf TUC_KON_000 { mandantId = $context.mandantId; clientSystemId = $context.clientsystemId; workplaceId = $context.workplaceId; ctId = $CtId; needCardSession=false; allWorkplaces=false }Tritt bei der Prüfung ein Fehler auf, so bricht die Operation mit dem Fehlercode aus TUC_KON_000 ab. |                                                                                                                                                      |
| Nr. 3 | TUC_KON_051a „Mit Anwender über Kartenterminal interagieren QR“ | Aufruf TUC_KON_051( ctId = $CtId; displayMessage = $DisplayMsg; waitTimer = $TimeOut; charSet = $charset)                                                                                                                                                                                                                                    |                                                                                                                                                      |


TUC_KON_051a „Mit Anwender über Kartenterminal interagieren QR“:
| Element                        | Beschreibung                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| Name                           | TUC_KON_051a „Mit Anwender über Kartenterminal interagieren QR“                                                                                                                                                                                                                                                                                                                                                                                                                                        |
| Beschreibung                   | Der TUC ermöglicht es, QR-Code und Data-Matrix-Code an das Display eines Kartenterminals zu senden.                                                                                                                                                                                                                                                                                                                                                                                                    |
| Auslöser                       | herstellerspezifische Außenoperation DisplayQRCode                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
| Vorbedingungen                 | • KT ist in CTM_CT_LIST vorhanden<br>• CT.CORRELATION = „aktiv“<br>• CT.CONNECTED = Ja<br>• CT.IS_PHYSICAL = Ja                                                                                                                                                                                                                                                                                                                                                                                        |
| Eingangsdaten                  | • ctId (Kartenterminalidentifikator)<br>• displayMessage – mandatory (Text zur Darstellung am KT, Länge durch KT begrenzt);<br>• waitTimer – mandatory (Wartezeit bis zur ersten Eingabe in Sekunden)<br>• charSet – mandatory (definiert "Character Set Index Value" des SICCT-Befehls)                                                                                                                                                                                                               |
| Komponenten                    | Konnektor, Kartenterminal                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
| Ausgangsdaten                  | opResult [OK] oder SOAP-Fault                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
| Nachbedingungen                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
| Standardablauf                 | 1\. KT-Lock von TUC_KON_051 reservieren.<br>2\. Der Konnektor MUSS via SICCT OUTPUT am CT displayMessage zur Anzeige bringen. Nach einer Wartezeit von waitTimer Sekunden MUSS der Konnektor die Anzeige des KT leeren. Für den SICCT OUTPUT Befehl muss das übergebene charset verwendet werden.<br>wenn:<br>charset = ISO 18004, dann "Character Set Index Value" = '30'<br>charset = ISO 16022, dann "Character Set Index Value" = '40'<br>3\. KT-Lock von TUC_KON_051 frei geben.                  |
| Varianten/ Alternativen        | Ist das Kartenterminal-Display durch einen anderen, zeitgleich im Konnektor ablaufenden Vorgang reserviert, wird Fehler 4039 geworfen.                                                                                                                                                                                                                                                                                                                                                                 |
| Fehlerfälle                    | (wie in TUC_KON_051)<br>Fehler in den folgenden Schritten des Ablaufs führen zum Aufruf von<br>TUC_KON_256 { topic = "CT/ERROR"; eventType = $ErrorType; severity = $Severity; parameters = („CtID=$ctId, Name=$CT.HOSTNAME, Error=$Fehlercode, Bedeutung=$Fehlertext“) }<br>(->1) Display und PinPad des Kartenterminals sind aktuell belegt (PIN, Eingabe, andere Ausgabe etc.), Fehlercode: 4039<br>(->1) Kartenterminal antwortet mit einer spezifischen Fehlermeldung, Fehlercode <gemäß [SICCT]> |
| Nichtfunktionale Anforderungen | keine                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| Zugehörige Diagramme           | keine                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |